### PR TITLE
Modifications to install ConductR on Core and Agent nodes

### DIFF
--- a/build-cluster-ec2.yml
+++ b/build-cluster-ec2.yml
@@ -196,8 +196,6 @@
   sudo: True
 
   vars:
-    CONDUCTR_SEED_PRIVATE_IP:
-      "{{ seeds_private[0] }}"
 # These are the default ConductR Private Agent roles - these roles may be overridden within the VARS_FILE
     CONDUCTR_PRIVATE_AGENT_ROLES:
       - web
@@ -206,9 +204,6 @@
   vars_files:
     - "{{ VARS_FILE }}"
 
-  vars:
-    CONDUCTR_AGENT_ROLES: "{{ CONDUCTR_PRIVATE_AGENT_ROLES }}"
-
   tasks:
     - include: python/tasks/main.yml
     - include: java/tasks/main.yml
@@ -216,6 +211,9 @@
     - include: docker/tasks/main.yml
       when: "{{ INSTALL_DOCKER }} == true"
     - include: conductr/tasks/install-agent.yml
+      vars:
+          CORE_OBSERVER_PRIVATE_IP: "{{ groups.seeds_private[0] }}"
+          CONDUCTR_AGENT_ROLES: "{{ CONDUCTR_PRIVATE_AGENT_ROLES }}"
     - include: bundle/tasks/config-elasticsearch.yml
 
 
@@ -233,9 +231,6 @@
   vars_files:
     - "{{ VARS_FILE }}"
 
-  vars:
-    CONDUCTR_AGENT_ROLES: "{{ CONDUCTR_PUBLIC_AGENT_ROLES }}"
-
   tasks:
     - include: python/tasks/main.yml
     - include: java/tasks/main.yml
@@ -244,8 +239,10 @@
       when: "{{ INSTALL_DOCKER }} == true"
     - include: haproxy/tasks/main.yml
     - include: conductr/tasks/install-agent.yml
+      vars:
+          CORE_OBSERVER_PRIVATE_IP: "{{ groups.seeds_private[0] }}"
+          CONDUCTR_AGENT_ROLES: "{{ CONDUCTR_PUBLIC_AGENT_ROLES }}"
     - include: bundle/tasks/config-haproxy.yml
-    - include: conductr/tasks/install-agent.yml
 
 - name: Install Bundles from the seed node
   hosts: seeds_public

--- a/conductr/tasks/install-agent.yml
+++ b/conductr/tasks/install-agent.yml
@@ -4,8 +4,6 @@
 
 - name: Install ConductR Agent
   apt: deb={{ REMOTE_WORK_DIR }}/{{ CONDUCTR_AGENT_PKG }}
-  vars:
-    CORE_OBSERVER_PRIVATE_IP: {{ groups.seeds_private[0]}}
 
 - command: rm {{ REMOTE_WORK_DIR }}/{{ CONDUCTR_AGENT_PKG }}
 
@@ -30,16 +28,15 @@
 - shell: "cat {{ REMOTE_WORK_DIR }}/az.txt"
   register: az
 
-- shell: 'echo -Dconductr.agent.roles.0={{ az.stdout }} | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
-  become: yes
-  become_method: sudo
+- debug:
+    var: CONDUCTR_AGENT_ROLES
 
-- shell: 'echo -Dconductr.agent.roles.{{ item.0 + 1  }}={{ item.1 }} | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
+- shell: 'echo -Dconductr.agent.roles.{{ item.0 }}={{ item.1 }} | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
   become: yes
   become_method: sudo
   with_indexed_items: "{{ CONDUCTR_AGENT_ROLES }}"
 
-- shell: 'echo -Dconductr.agent.storage-dir={{ CONDUCTR_AGENT_WORK_DIR }}/bundles | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
+- shell: 'echo -Dconductr.agent.roles.{{ CONDUCTR_AGENT_ROLES | length }}={{ az.stdout }} | sudo tee -a /usr/share/conductr-agent/conf/conductr-agent.ini'
   become: yes
   become_method: sudo
 

--- a/conductr/tasks/install-core.yml
+++ b/conductr/tasks/install-core.yml
@@ -1,11 +1,11 @@
 ---
 - name: Copy ConductR
-  synchronize: src=conductr/files/{{ CONDUCTR_PKG }} dest={{ CONDUCTR_CORE_WORK_DIR }}
+  synchronize: src=conductr/files/{{ CONDUCTR_PKG }} dest={{ REMOTE_WORK_DIR }}
 
 - name: Install ConductR
-  apt: deb={{ CONDUCTR_CORE_WORK_DIR }}/{{ CONDUCTR_PKG }}
+  apt: deb={{ REMOTE_WORK_DIR }}/{{ CONDUCTR_PKG }}
 
-- command: rm {{ CONDUCTR_CORE_WORK_DIR }}/{{ CONDUCTR_PKG }}
+- command: rm {{ REMOTE_WORK_DIR }}/{{ CONDUCTR_PKG }}
 
 - name: Setup Python3 Pip
   apt: name={{ item }} state=latest


### PR DESCRIPTION
- Ensure variables required by install agent task is passed correctly from `build-cluster-ec2.yml` main playbook into `install-agent.yml` playbook.
- Remove extra calls to `install-agent.yml` playbook from `build-cluster-ec2.yml`.
- `install-core.yml` playbook uses `REMOTE_WORK_DIR` variable for transferring the `.deb` package.
- `install-agent.yml` playbook: remove `CONDUCTR_AGENT_WORK_DIR` as it's now configured by default.
- `install-agent.yml` playbook: modify AZ roles assignment to supported valid jinja expression.